### PR TITLE
PR: add dependabot configuration to scan gradle dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,6 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 0
       
-
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:


### PR DESCRIPTION
## Description
Dependabot config is toegevoegd zodat gradle dependencies ook meegenomen worden in de wekelijkse scan voor dependency vulnerabilities. Er worden geen PRs geopend door dependabot in de huidige configuratie.

### Related Issue
- #219 

### Type of Change
- [x] Nieuwe feature
- [ ] Code verbeteringen
- [ ] Bug fix
- [ ] Documentatie update

### Checklist
- Ik bevestig dat:

    - ik een eigen review hebt gedaan van mijn code
    - ik comments hebt toegevoegt aan mijn code, indien nodig
    - ik gerelateerde documentatie indien nodig hebt geüpdatet
    - mijn veranderingen geen nieuwe fouten geven

### Screenshots/references