### PR TITLE
PR: 265 Maken van Layered Architecture Diagram

### DIFF
--- a/src/test/kotlin/nl/hu/inno/dashboard/architecture/ArchTest.kt
+++ b/src/test/kotlin/nl/hu/inno/dashboard/architecture/ArchTest.kt
@@ -19,16 +19,14 @@ class ArchTest {
             .layer("Service").definedBy("..application..")
             .layer("Domain").definedBy("..domain..")
             .layer("Persistence").definedBy("..data..")
-            .layer("Exception").definedBy("..exception..")
 
             .whereLayer("Controller").mayNotBeAccessedByAnyLayer()
             .whereLayer("Controller").mayOnlyAccessLayers("Service")
 
             .whereLayer("Service").mayOnlyBeAccessedByLayers("Controller", "Service")
-            .whereLayer("Service").mayOnlyAccessLayers("Service", "Domain", "Persistence", "Exception")
+            .whereLayer("Service").mayOnlyAccessLayers("Service", "Domain", "Persistence")
 
             .whereLayer("Domain").mayOnlyBeAccessedByLayers("Service", "Persistence")
-            .whereLayer("Domain").mayOnlyAccessLayers("Exception")
 
             .whereLayer("Persistence").mayOnlyBeAccessedByLayers("Service")
             .whereLayer("Persistence").mayOnlyAccessLayers("Domain")
@@ -41,7 +39,8 @@ class ArchTest {
                     "org.springframework..",
                     "org.apache.commons..",
                     "kotlin..",
-                    "org.jetbrains.."
+                    "org.jetbrains..",
+                    "nl.hu.inno.dashboard.exception.."
                 )
             )
 


### PR DESCRIPTION
## Description
De layered architecture test is aangepast om duidelijker te zijn: de `exception` package wordt niet meer als 'layer' bestempeld en in plaats daarvan wordt deze package nu genegeerd tijdens de test. Dit omdat de `exception` package door meerdere lagen gebruikt mag worden en dit niet de intended architecture negeert.

### Related Issue
- #265 

### Type of Change
- [ ] Nieuwe feature
- [x] Code refactoring
- [ ] Bug fix
- [ ] Documentatie update
- [ ] Styling update

### Screenshots/references