### PR TITLE
PR: ensure courses directory gets created if it does not already exist

### DIFF
--- a/src/main/kotlin/nl/hu/inno/dashboard/filemonitor/application/UserDataCsvMonitorService.kt
+++ b/src/main/kotlin/nl/hu/inno/dashboard/filemonitor/application/UserDataCsvMonitorService.kt
@@ -58,7 +58,7 @@ class UserDataCsvMonitorService(
     }
 
     private fun createObserver(): FileAlterationObserver {
-        verifyCsvDirectoryExists()
+        verifyCoursesDirectoryExists()
 
         val observer = FileAlterationObserver.builder()
             .setPath(csvDirectoryPath)
@@ -81,8 +81,13 @@ class UserDataCsvMonitorService(
         }
     }
 
-    private fun verifyCsvDirectoryExists() {
+    private fun verifyCoursesDirectoryExists() {
         val dir = File(csvDirectoryPath)
+
+        if (!dir.exists()) {
+//            create the courses folder inside the shared-data volume if it does not exist
+            dir.mkdirs()
+        }
         if (!dir.exists() || !dir.isDirectory || !dir.canRead()) {
             throw IllegalStateException("Directory $csvDirectoryPath does not exist or is not readable.")
         }

--- a/src/test/kotlin/nl/hu/inno/dashboard/filemonitor/application/UserDataCsvMonitorServiceTest.kt
+++ b/src/test/kotlin/nl/hu/inno/dashboard/filemonitor/application/UserDataCsvMonitorServiceTest.kt
@@ -59,21 +59,41 @@ class UserDataCsvMonitorServiceTest {
     }
 
     @Test
-    fun createObserver_throwsException_whenDirectoryDoesNotExist() {
-        val serviceWithInvalidDir = UserDataCsvMonitorService(
-            "/invalid/path",
-            "invalid",
-            intervalInMillis,
-            dashboardService,
-            hashChecker
-        )
-        val method = UserDataCsvMonitorService::class.java.getDeclaredMethod("createObserver")
+    fun verifyCoursesDirectoryExists_throwsException_whenDirectoryDoesNotExistAfterCreation() {
+        val dirPath = "$pathToSharedDataVolume/$coursesDirectory"
+        val dir = File(dirPath)
+        if (dir.exists()) {
+            dir.deleteRecursively()
+        }
+        dir.parentFile.mkdirs()
+        dir.createNewFile()
+
+        val method = UserDataCsvMonitorService::class.java.getDeclaredMethod("verifyCoursesDirectoryExists")
         method.isAccessible = true
 
         val exception = assertThrows(InvocationTargetException::class.java) {
-            method.invoke(serviceWithInvalidDir)
+            method.invoke(service)
         }
         assertTrue(exception.cause is IllegalStateException)
+        dir.delete()
+    }
+
+    @Test
+    fun verifyCoursesDirectoryExists_createsDirectory_whenMissing() {
+        val dirPath = "$pathToSharedDataVolume/$coursesDirectory"
+        val dir = File(dirPath)
+        if (dir.exists()) {
+            dir.deleteRecursively()
+        }
+        assertFalse(dir.exists())
+
+        val method = UserDataCsvMonitorService::class.java.getDeclaredMethod("verifyCoursesDirectoryExists")
+        method.isAccessible = true
+
+        assertDoesNotThrow { method.invoke(service) }
+        assertTrue(dir.exists())
+        assertTrue(dir.isDirectory)
+        dir.deleteRecursively()
     }
 
     @Test


### PR DESCRIPTION
## Description
FileMonitor maakt nu de `courses` folder automatisch aan als deze niet bestaat.

### Related Issue
- 

### Type of Change
- [ ] Nieuwe feature
- [ ] Code refactoring
- [x] Bug fix
- [ ] Documentatie update
- [ ] Styling update

### Screenshots/references